### PR TITLE
chore: upgrade to Clerk Core 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@clerk/tanstack-react-start": "^0.27.17",
-    "@tanstack/react-router": "1.154.14",
-    "@tanstack/react-router-devtools": "1.154.14",
-    "@tanstack/react-start": "1.154.14",
+    "@clerk/tanstack-react-start": "^1.0.0-canary.v20260217092349",
+    "@tanstack/react-router": "1.160.2",
+    "@tanstack/react-router-devtools": "1.160.2",
+    "@tanstack/react-start": "1.160.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@clerk/tanstack-react-start": "^1.0.0-canary.v20260217092349",
+    "@clerk/tanstack-react-start": "^1.0.0",
     "@tanstack/react-router": "1.160.2",
     "@tanstack/react-router-devtools": "1.160.2",
     "@tanstack/react-start": "1.160.2",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,6 @@
 import {
-  SignedIn,
+  Show,
   UserButton,
-  SignedOut,
   SignInButton,
 } from '@clerk/tanstack-react-start'
 import { createFileRoute } from '@tanstack/react-router'
@@ -14,14 +13,14 @@ function Home() {
   return (
     <div>
       <h1>Index Route</h1>
-      <SignedIn>
+      <Show when="signed-in">
         <p>You are signed in</p>
         <UserButton />
-      </SignedIn>
-      <SignedOut>
+      </Show>
+      <Show when="signed-out">
         <p>You are signed out</p>
         <SignInButton />
-      </SignedOut>
+      </Show>
     </div>
   )
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,10 +14,4 @@ export default defineConfig({
     tanstackStart(),
     viteReact(),
   ],
-  // See https://github.com/TanStack/router/issues/5738
-  // resolve: {
-  //   alias: [
-  //     { find: 'use-sync-external-store/shim/index.js', replacement: 'react', }
-  //   ]
-  // }
 })


### PR DESCRIPTION
## Summary

- Upgrades `@clerk/tanstack-react-start` from `^0.27.17` to `^1.0.0-`
- Upgrades TanStack packages from `1.154.14` to `1.160.2` (required peer dependency)
- Migrates `SignedIn`/`SignedOut` components to the new `Show` component

## Test plan

- [x] `npm run build` passes