### PR TITLE
Add a "Protect your pages" step (server-side auth read)

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,8 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ProtectedRouteImport } from './routes/protected'
 import { Route as IndexRouteImport } from './routes/index'
 
+const ProtectedRoute = ProtectedRouteImport.update({
+  id: '/protected',
+  path: '/protected',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +25,39 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/protected': typeof ProtectedRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/protected': typeof ProtectedRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/protected': typeof ProtectedRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/protected'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/protected'
+  id: '__root__' | '/' | '/protected'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ProtectedRoute: typeof ProtectedRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/protected': {
+      id: '/protected'
+      path: '/protected'
+      fullPath: '/protected'
+      preLoaderRoute: typeof ProtectedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +70,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ProtectedRoute: ProtectedRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,7 +3,7 @@ import {
   UserButton,
   SignInButton,
 } from '@clerk/tanstack-react-start'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
   component: Home,
@@ -15,6 +15,7 @@ function Home() {
       <h1>Index Route</h1>
       <Show when="signed-in">
         <p>You are signed in</p>
+        <Link to="/protected">Protected</Link>
         <UserButton />
       </Show>
       <Show when="signed-out">

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -1,0 +1,32 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/react-start'
+import { auth } from '@clerk/tanstack-react-start/server'
+
+const authStateFn = createServerFn().handler(async () => {
+  // Use `auth()` to read the session on the server and protect this route.
+  // Unlike the `<Show>` component, which only controls what renders, this is
+  // the real access check: a signed-out user who navigates here is redirected.
+  const { isAuthenticated, userId } = await auth()
+
+  if (!isAuthenticated) {
+    throw redirect({ to: '/' })
+  }
+
+  return { userId }
+})
+
+export const Route = createFileRoute('/protected')({
+  component: Protected,
+  beforeLoad: async () => await authStateFn(),
+  loader: async ({ context }) => ({ userId: context.userId }),
+})
+
+function Protected() {
+  const { userId } = Route.useLoaderData()
+
+  return (
+    <p>
+      Welcome! Your user ID is <code>{userId}</code>.
+    </p>
+  )
+}


### PR DESCRIPTION
Adds a `/protected` route to the quickstart that reads the signed-in user on the **server** (via `createServerFn` + `auth()`, redirecting in `beforeLoad`) and bounces signed-out visitors to `/`, plus a **"Protected"** link shown only when signed in.

## Why

The quickstart's docs already describe a "Protect your pages" step, but this example repo didn't actually implement it — it only had the client-side `<Show>` components. This brings the repo in line with its own docs and with the other full-stack quickstarts, and makes the model explicit:

> **Client components control visibility. The server controls access.**

## What's here

- A `/protected` route using `createServerFn` + `auth()` (`@clerk/tanstack-react-start/server`), redirecting signed-out users to `/` and rendering the user's ID when signed in.
- A "Protected" link in the index route, gated by `<Show when="signed-in">`.

## Verification

`pnpm build` (vite build + `tsc --noEmit`) passes on current deps; the `/protected` route bundles and the route tree regenerates.

Part of DOCS-11853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
