### PR TITLE
Ignore dist/ build output in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ yarn.lock
 .vinxi
 
 /build/
+/dist/
 /api/
 /server/build
 /public/build


### PR DESCRIPTION
## Summary

`vite build` writes to `dist/`, but `.gitignore` didn't cover it — leaving the build output as an untracked directory a contributor could accidentally commit.

## Changes

- Add `/dist/` to `.gitignore`, alongside the other build/output dirs (`/build/`, `/server/build`, `/public/build`).

## References

- [DOCS-11867](https://linear.app/clerk/issue/DOCS-11867/clerk-tanstack-react-start-quickstart-gitignore-does-not-ignore-dist)
